### PR TITLE
Support for nativescript 5 and 6

### DIFF
--- a/handle-file.android.d.ts
+++ b/handle-file.android.d.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'data/observable';
+import { Observable } from 'tns-core-modules/data/observable';
 export interface Params {
     url: string;
     name: string;

--- a/handle-file.android.ts
+++ b/handle-file.android.ts
@@ -1,7 +1,7 @@
-import * as fs from "file-system";
-import * as application from "application";
-import * as  http from "http";
-import { Observable } from 'data/observable';
+import * as fs from 'tns-core-modules/file-system';
+import * as application from 'tns-core-modules/application';
+import * as  http from 'tns-core-modules/http';
+import { Observable } from 'tns-core-modules/data/observable';
 
 export interface Params {
     url: string;

--- a/handle-file.ios.d.ts
+++ b/handle-file.ios.d.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'data/observable';
+import { Observable } from 'tns-core-modules/data/observable';
 export interface Params {
     url: string;
     name: string;

--- a/handle-file.ios.ts
+++ b/handle-file.ios.ts
@@ -1,7 +1,7 @@
-import * as fs from "file-system";
-import * as http from "http";
-import * as utils from "tns-core-modules/utils/utils";
-import { Observable } from 'data/observable';
+import * as fs from 'tns-core-modules/file-system';
+import * as http from 'tns-core-modules/http';
+import * as utils from 'tns-core-modules/utils/utils';
+import { Observable } from 'tns-core-modules/data/observable';
 
 export interface Params {
     url: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'data/observable';
+import { Observable } from 'tns-core-modules/data/observable';
 export interface Params {
     url: string;
     name: string;


### PR DESCRIPTION
Nativescript 5.4.0 is not accepting import with relative path, accepts only import with absolute path. Fixed the call with absolute path so the plugin is compatible with the new version of Nativescript 5 and 6.